### PR TITLE
added basedir to the jade options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ elixir.extend('jade', function (options) {
         'compiler'
     );
 
+    jade_options.basedir = options.baseDir + options.src;
+
     gulp.task('jade', function () {
         return gulp.src(gulp_src)
             .pipe(plumber())


### PR DESCRIPTION
If you want to use a base / include in your jade files (eg. include "/dir/off/basedir/file.jade") you have to pass the basedir option to the jade call... this adds that.
